### PR TITLE
Fixed parse AWS_S3_URL

### DIFF
--- a/config/plugins/wordpress/wordpress-s3uploads.php
+++ b/config/plugins/wordpress/wordpress-s3uploads.php
@@ -4,13 +4,13 @@
  * @url: https://github.com/humanmade/S3-Uploads
  */
 if (!empty(getenv('AWS_S3_URL'))) {
-    $env = parse_url(getenv('AWS_S3_URL'));
+    $env = sscanf(getenv('AWS_S3_URL'), 's3://%[^:]:%[^@]@s3-%[^.].amazonaws.com/%s');
 
     define('S3_UPLOADS_AUTOENABLE', true);
-    define('S3_UPLOADS_KEY', $env['user']);
-    define('S3_UPLOADS_SECRET', $env['pass']);
-    define('S3_UPLOADS_REGION', str_replace(array('s3-', '.amazonaws.com'), array('', ''), $env['host']));
-    define('S3_UPLOADS_BUCKET', ltrim($env['path'], '/'));
+    define('S3_UPLOADS_KEY', $env[0]);
+    define('S3_UPLOADS_SECRET', $env[1]);
+    define('S3_UPLOADS_REGION', $env[2]);
+    define('S3_UPLOADS_BUCKET', $env[3]);
 
     unset($env);
 } else {


### PR DESCRIPTION
fix: #26 

In API reference, a secret access key is just String. It doesn't have pattern.
https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html

I'm not sure whether it includes ``@`` or not but I often see a ``\`` but I have never seen the ``@`` for now.

How about using ``sscanf``?
