### PR TITLE
Upgrade to Heroku-18

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
 	  "bin/scripts/postdeploy.sh"
 	]
   },
-  "stack": "cedar-14",
+  "stack": "heroku-18",
   "env": {
 	"AUTH_KEY": {
 	  "description": "A secret key to increase security of stored information.",


### PR DESCRIPTION
Upgrade Heroku stack as the old “cedar-14” is deprecated and won’t build soon.